### PR TITLE
fix:fix akv not work in azure vm

### DIFF
--- a/internal/cloud/keyvault.go
+++ b/internal/cloud/keyvault.go
@@ -12,25 +12,71 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 )
 
-// NewAzureClient returns a new Azure Key Vault client authorized in the order:
-// 1. Client credentials
-// 2. Client certificate
-// 3. Username password
-// 4. MSI
-// 5. Azure CLI 2.0
+// clientAuthMode is the authorize mode used by plugin
+type clientAuthMethod string
+
+// set of auth errors
+var (
+	errAuthorizerFromMI  = errors.New("authorized from Managed Identity failed, please ensure you have assigned identity to your resource")
+	errAuthorizerFromCLI = errors.New("authorized from Azure CLI 2.0 failed, please ensure you have logged in using the 'az' command line tool")
+	errUnknownAuthorizer = errors.New("unknown authorize method, please use a supported authorize method according to the document")
+)
+
+const (
+	// authMethodKey is the environment variable plugin used
+	authMethodKey = "AKV_AUTH_METHOD"
+	// authorizerFromMI auth akv from Managed Identity
+	// The auth order will be:
+	// 1. Client credentials
+	// 2. Client certificate
+	// 3. Username password
+	// 4. MSI
+	authorizerFromMI clientAuthMethod = "AKV_AUTH_FROM_MI"
+
+	// authorizerFromCLI auth akv from Azure cli 2.0
+	authorizerFromCLI clientAuthMethod = "AKV_AUTH_FROM_CLI"
+
+	// defaultAuthMethod is the default auth method if user doesn't provide an environment variable
+	// the default value will be authorizerFromCLI
+	defaultAuthMethod = authorizerFromCLI
+)
+
+// getAzureClientAuthMethod get authMethod from environment variable
+func getAzureClientAuthMethod() clientAuthMethod {
+	mode := clientAuthMethod(os.Getenv(authMethodKey))
+	if mode == "" {
+		return defaultAuthMethod
+	}
+	return mode
+}
+
+// NewAzureClient returns a new Azure Key Vault client
+// By default, the authorizer will be from Azure CLI
+// If user sets AKV_AUTH_METHOD to AKV_AUTH_FROM_MI, it will use MI instead
 func NewAzureClient() (*keyvault.BaseClient, error) {
-	authorizer, err := auth.NewAuthorizerFromEnvironment()
-	if err != nil {
+	var (
+		authorizer autorest.Authorizer
+		err        error
+	)
+	authMethod := getAzureClientAuthMethod()
+	switch authMethod {
+	case authorizerFromMI:
+		authorizer, err = auth.NewAuthorizerFromEnvironment()
+		if err != nil {
+			return nil, fmt.Errorf("%w, origin error: %s", errAuthorizerFromMI, err.Error())
+		}
+	case authorizerFromCLI:
 		authorizer, err = auth.NewAuthorizerFromCLI()
 		if err != nil {
-			return nil, errors.New("Unable to authenticate with the Azure API, ensure you have your credentials set as environment variables, " +
-				"or you have logged in using the 'az' command line tool")
+			return nil, fmt.Errorf("%w, origin error: %s", errAuthorizerFromCLI, err.Error())
 		}
+	default:
+		return nil, errUnknownAuthorizer
 	}
-
 	client := keyvault.New()
 	client.Authorizer = authorizer
 	return &client, nil


### PR DESCRIPTION
## What
Add Managed Identity auth mode.
The default auth mode will be Azure CLI.
Set the below environment variable will switch to MI mode.
```
export AKV_AUTH_METHOD="AKV_AUTH_FROM_MI"
```

Signed-off-by: zaihaoyin <zaihaoyin@microsoft.com>