### PR TITLE
Update setup.sh notation cli commands to be compatible with RC.1

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -55,22 +55,22 @@ function getNotationProject {
     echo ''
     echo "Setting up the Notation CLI..."
 
-    # Choose a binary
-    timestamp=20220121081115
-    commit=17c7607
-    
     # Check if ~/bin is there, if not create it 
     [ -d ~/bin ] || mkdir ~/bin
 
     # Download Notation from pre-release
-    curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/feat-kv-extensibility/notation-feat-kv-extensibility-$timestamp-$commit.tar.gz > /dev/null 2>&1
+    curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/v1.0.0-rc.1/notation_1.0.0-rc.1_linux_amd64.tar.gz > /dev/null 2>&1
 
     # Extract notation
     mkdir ./tmp
     tar xvzf notation.tar.gz -C ./tmp > /dev/null 2>&1
 
     # Copy the notation cli to your bin directory
-    tar xvzf ./tmp/notation_0.0.0-SNAPSHOT-${commit}_${osVersion}_amd64.tar.gz -C ~/bin notation > /dev/null 2>&1
+    # tar xvzf ./tmp/notation_0.0.0-SNAPSHOT-${commit}_${osVersion}_amd64.tar.gz -C ~/bin notation > /dev/null 2>&1
+    cp ./tmp/notation $HOME/bin 
+
+    # Add $HOME/bin to $PATH
+    export PATH="$HOME/bin:$PATH"
 
     # Clean up
     rm -rf ./tmp notation.tar.gz
@@ -86,7 +86,7 @@ function installNotationKvPlugin {
 
     # Download the plugin
     curl -Lo notation-azure-kv.tar.gz \
-        https://github.com/Azure/notation-azure-kv/releases/download/v0.1.0-alpha.1/notation-azure-kv_0.1.0-alpha.1_${osVersion}_amd64.tar.gz > /dev/null 2>&1
+        https://github.com/Azure/notation-azure-kv/releases/download/v0.5.0-rc.1/notation-azure-kv_0.5.0-rc.1_${osVersion}_amd64.tar.gz > /dev/null 2>&1
 
     # Extract to the plugin directory    
     tar xvzf notation-azure-kv.tar.gz -C ~/.config/notation/plugins/azure-kv notation-azure-kv > /dev/null 2>&1
@@ -212,9 +212,10 @@ function createSigningCertforKV {
         },
         "x509CertificateProperties": {
         "ekus": [
-            "1.3.6.1.5.5.7.3.1",
-            "1.3.6.1.5.5.7.3.2",
             "1.3.6.1.5.5.7.3.3"
+        ],
+        "key_usage": [
+            "digitalSignature"
         ],
         "subject": "CN=${keySubjectName}",
         "validityInMonths": 12
@@ -236,14 +237,11 @@ EOF
     # Use notation to add the key id to the kms keys and certs
     echo ''
     echo "Using Notation to add the key ID to Key Management Service..."
-    notation key remove $keyName > /dev/null 2>&1 
-    notation key add --name $keyName --plugin azure-kv --id $keyID --kms
-    notation cert remove $keyName > /dev/null 2>&1 
-    notation cert add --name $keyName --plugin azure-kv --id $keyID --kms
+    notation key delete $keyName > /dev/null 2>&1 
+    notation key add --plugin azure-kv --id $keyID $keyName
 
     # Checks and balances
     notation key ls
-    notation cert ls
 }
 
 function secureAKSwithRatify {
@@ -397,8 +395,8 @@ function deployInfra {
 }
 
 function setup {
-    getNotationProject
-    installNotationKvPlugin
+    # getNotationProject
+    # installNotationKvPlugin
     spCreate
     deployInfra
     acrTokenCreate
@@ -406,7 +404,7 @@ function setup {
     createSigningCertforKV
     secureAKSwithRatify
     buildImageandSign
-    notes
+    # notes
 }
 
 # Call setup function

--- a/setup.sh
+++ b/setup.sh
@@ -395,8 +395,8 @@ function deployInfra {
 }
 
 function setup {
-    # getNotationProject
-    # installNotationKvPlugin
+    getNotationProject
+    installNotationKvPlugin
     spCreate
     deployInfra
     acrTokenCreate
@@ -404,7 +404,7 @@ function setup {
     createSigningCertforKV
     secureAKSwithRatify
     buildImageandSign
-    # notes
+    notes
 }
 
 # Call setup function


### PR DESCRIPTION
Resolves issue [#53](https://github.com/Azure/notation-azure-kv/issues/53#issuecomment-1369896821)

I also removed the `notation cert add` command because it's not used to verify the certificate in the tutorials and the changes made in RC1 broke the previous syntax. If you'd like to add it back in, please let me know.