### PR TITLE
fix: update error message

### DIFF
--- a/cmd/notation-azure-kv/sign.go
+++ b/cmd/notation-azure-kv/sign.go
@@ -53,7 +53,7 @@ func runSign(ctx *cli.Context) error {
 		if errors.As(err, &rerr) {
 			return rerr
 		}
-		return fmt.Errorf("failed to sign payload: %w", err)
+		return err
 	}
 
 	jsonResp, err := json.Marshal(resp)

--- a/internal/cloud/keyvault.go
+++ b/internal/cloud/keyvault.go
@@ -68,12 +68,12 @@ func NewAzureClient() (*keyvault.BaseClient, error) {
 	case authorizerFromMI:
 		authorizer, err = auth.NewAuthorizerFromEnvironment()
 		if err != nil {
-			return nil, fmt.Errorf("%w, origin error: %s", errAuthorizerFromMI, err.Error())
+			return nil, fmt.Errorf("%w, origin error: %w", errAuthorizerFromMI, err)
 		}
 	case authorizerFromCLI:
 		authorizer, err = auth.NewAuthorizerFromCLI()
 		if err != nil {
-			return nil, fmt.Errorf("%w, origin error: %s", errAuthorizerFromCLI, err.Error())
+			return nil, fmt.Errorf("%w, origin error: %w", errAuthorizerFromCLI, err)
 		}
 	default:
 		return nil, errUnknownAuthorizer
@@ -167,7 +167,7 @@ func (k *Key) Sign(ctx context.Context, algorithm keyvault.JSONWebKeySignatureAl
 	return base64.RawURLEncoding.DecodeString(*res.Result)
 }
 
-// Certificate returns the X.509 certificate chain associated with the key.
+// CertificateChain returns the X.509 certificate chain associated with the key.
 func (k *Key) CertificateChain(ctx context.Context) ([]*x509.Certificate, error) {
 	// Need a certificate chain to pass the notation validation
 	// GetCertificate only returns the leaf certificate

--- a/internal/cloud/keyvault.go
+++ b/internal/cloud/keyvault.go
@@ -22,9 +22,9 @@ type clientAuthMethod string
 
 // set of auth errors
 var (
-	errAuthorizerFromMI  = errors.New("authorized from Managed Identity failed, please ensure you have assigned identity to your resource")
-	errAuthorizerFromCLI = errors.New("authorized from Azure CLI 2.0 failed, please ensure you have logged in using the 'az' command line tool")
-	errUnknownAuthorizer = errors.New("unknown authorize method, please use a supported authorize method according to the document")
+	errMsgAuthorizerFromMI  = "authorized from Managed Identity failed, please ensure you have assigned identity to your resource"
+	errMsgAuthorizerFromCLI = "authorized from Azure CLI 2.0 failed, please ensure you have logged in using the 'az' command line tool"
+	errMsgUnknownAuthorizer = "unknown authorize method, please use a supported authorize method according to the document"
 )
 
 const (
@@ -68,15 +68,15 @@ func NewAzureClient() (*keyvault.BaseClient, error) {
 	case authorizerFromMI:
 		authorizer, err = auth.NewAuthorizerFromEnvironment()
 		if err != nil {
-			return nil, fmt.Errorf("%w, origin error: %w", errAuthorizerFromMI, err)
+			return nil, fmt.Errorf("%s, origin error: %w", errMsgAuthorizerFromMI, err)
 		}
 	case authorizerFromCLI:
 		authorizer, err = auth.NewAuthorizerFromCLI()
 		if err != nil {
-			return nil, fmt.Errorf("%w, origin error: %w", errAuthorizerFromCLI, err)
+			return nil, fmt.Errorf("%s, origin error: %w", errMsgAuthorizerFromCLI, err)
 		}
 	default:
-		return nil, errUnknownAuthorizer
+		return nil, errors.New(errMsgUnknownAuthorizer)
 	}
 	client := keyvault.New()
 	client.Authorizer = authorizer

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -1,12 +1,17 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
+	"os"
 
 	"golang.org/x/crypto/pkcs12"
 )
+
+const certBundleKey = "certbundle"
 
 func parsePEM(data []byte) ([]*x509.Certificate, error) {
 	var certs []*x509.Certificate
@@ -58,4 +63,52 @@ func ParseCertificates(data []byte, contentType string) (certs []*x509.Certifica
 		return parsePKCS12(data)
 	}
 	return parsePEM(data)
+}
+
+// CompleteCertificateChain returns the complete certificate chain by appending the parent certificate from the certificate bundle to the original certificate chain.
+// If the certificate bundle path is not set in the pluginConfig, it returns the original certificate chain.
+// If an error occurs while reading the certificate bundle or parsing its PEM, it returns a nil slice and a non-nil error indicating the failure reason.
+func CompleteCertificateChain(pluginConfig map[string]string, originalCerts []*x509.Certificate) ([]*x509.Certificate, error) {
+	certBundlePath, ok := pluginConfig[certBundleKey]
+	// if certbundle is not set, return the original certs
+	if !ok {
+		return originalCerts, nil
+	}
+
+	certBundleBytes, err := os.ReadFile(certBundlePath)
+	if err != nil {
+		return nil, err
+	}
+
+	certBundle, err := parsePEM(certBundleBytes)
+	if err != nil {
+		return nil, err
+	}
+	return completeCertChain(originalCerts, certBundle)
+}
+
+// completeCertChain appends the parent certificate from the certificate bundle to the original certificate chain.
+// It returns the complete certificate chain along with a nil error if successful, otherwise it returns a nil slice and a non-nil error indicating the failure reason.
+func completeCertChain(originalCerts, certBundle []*x509.Certificate) ([]*x509.Certificate, error) {
+	if len(originalCerts) == 0 {
+		return nil, errors.New("the original certificate chain is empty")
+	}
+
+	if len(certBundle) == 0 {
+		return nil, errors.New("the certificate bundle is empty")
+	}
+
+	oldestCert := originalCerts[len(originalCerts)-1]
+	parentCertIndex := -1
+	for i, cert := range certBundle {
+		if bytes.Equal(oldestCert.RawIssuer, cert.RawSubject) {
+			parentCertIndex = i
+			break
+		}
+	}
+
+	if parentCertIndex == -1 {
+		return nil, errors.New("cannot find the parent for the original certificate chain from the certificate bundle")
+	}
+	return append(originalCerts, certBundle[parentCertIndex:]...), nil
 }

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -84,14 +84,6 @@ func MergeCertificateChain(certBundlePath string, originalCerts []*x509.Certific
 		return nil, errors.New("the certificate bundle file is empty or not in PEM format")
 	}
 
-	// merge certificate chain
-	return mergeCertificateChain(originalCerts, certBundle)
-}
-
-// mergeCertificateChain is a helper function for MergeCertificateChain function.
-// It obtains the originalCerts and a new certBundle and appends the latter
-// to the former then calls ValidateCertChain function, returns the result.
-func mergeCertificateChain(originalCerts, certBundle []*x509.Certificate) ([]*x509.Certificate, error) {
 	return ValidateCertificateChain(append(originalCerts, certBundle...))
 }
 

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -121,7 +121,7 @@ func ValidateCertificateChain(certs []*x509.Certificate) ([]*x509.Certificate, e
 	// verify and build certificate chain for leaf.
 	certChains, err := leafCert.Verify(opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to validate certificate chain. error: %w", err)
+		return nil, err
 	}
 	return certChains[0], nil
 }

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -6,7 +6,11 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 
 	"golang.org/x/crypto/pkcs12"
 )
@@ -65,50 +69,94 @@ func ParseCertificates(data []byte, contentType string) (certs []*x509.Certifica
 	return parsePEM(data)
 }
 
-// CompleteCertificateChain returns the complete certificate chain by appending the parent certificate from the certificate bundle to the original certificate chain.
+// MergeCertificateChain returns the complete certificate chain by appending the parent certificate from the certificate bundle to the original certificate chain.
 // If the certificate bundle path is not set in the pluginConfig, it returns the original certificate chain.
 // If an error occurs while reading the certificate bundle or parsing its PEM, it returns a nil slice and a non-nil error indicating the failure reason.
-func CompleteCertificateChain(pluginConfig map[string]string, originalCerts []*x509.Certificate) ([]*x509.Certificate, error) {
+func MergeCertificateChain(pluginConfig map[string]string, originalCerts []*x509.Certificate) ([]*x509.Certificate, error) {
+	// get cert bundle path
+	if pluginConfig == nil {
+		return originalCerts, nil
+	}
 	certBundlePath, ok := pluginConfig[certBundleKey]
-	// if certbundle is not set, return the original certs
 	if !ok {
 		return originalCerts, nil
 	}
 
+	// validate certificate bundle path
+	certBundlePath = strings.Trim(certBundlePath, " ")
+	basename := filepath.Base(certBundlePath)
+	if !isValidFileName(basename) {
+		return nil, fmt.Errorf("the filename of certificate bundle path is not cross-platform compatible. filename: %s", basename)
+	}
+
+	// read certificate bundle
 	certBundleBytes, err := os.ReadFile(certBundlePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot open user provided cert bundle file %q with err: %w", certBundlePath, err)
 	}
-
 	certBundle, err := parsePEM(certBundleBytes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot parse user provided cert bundle file %q with err: %w", certBundlePath, err)
 	}
-	return completeCertChain(originalCerts, certBundle)
+	// merge certificate chain
+	return mergeCertChain(originalCerts, certBundle)
 }
 
-// completeCertChain appends the parent certificate from the certificate bundle to the original certificate chain.
+// mergeCertChain appends the parent certificate from the certificate bundle to the original certificate chain.
 // It returns the complete certificate chain along with a nil error if successful, otherwise it returns a nil slice and a non-nil error indicating the failure reason.
-func completeCertChain(originalCerts, certBundle []*x509.Certificate) ([]*x509.Certificate, error) {
+func mergeCertChain(originalCerts, certBundle []*x509.Certificate) ([]*x509.Certificate, error) {
 	if len(originalCerts) == 0 {
-		return nil, errors.New("the original certificate chain is empty")
+		return nil, errors.New("the certificate chain accessed from Azure Key Vault is empty")
 	}
-
 	if len(certBundle) == 0 {
-		return nil, errors.New("the certificate bundle is empty")
+		return nil, errors.New("the certificate bundle file is empty or in a unsupported format")
+	}
+	// leaf certificate
+	leafCert := originalCerts[0]
+
+	// generate certificate pools
+	rootPool := x509.NewCertPool()
+	intermediatePool := x509.NewCertPool()
+
+	// verify options
+	opts := x509.VerifyOptions{
+		Roots:         rootPool,
+		Intermediates: intermediatePool,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 
-	oldestCert := originalCerts[len(originalCerts)-1]
-	parentCertIndex := -1
-	for i, cert := range certBundle {
-		if bytes.Equal(oldestCert.RawIssuer, cert.RawSubject) {
-			parentCertIndex = i
-			break
+	// try to validate the certificate chain by using the original certificates
+	// accessed from AKV.
+	for _, cert := range originalCerts[1:] {
+		if bytes.Equal(cert.RawIssuer, cert.RawSubject) {
+			rootPool.AddCert(cert)
+		} else {
+			intermediatePool.AddCert(cert)
 		}
 	}
-
-	if parentCertIndex == -1 {
-		return nil, errors.New("cannot find the parent for the original certificate chain from the certificate bundle")
+	// verify and build certificate chain for leaf CA.
+	// skip the error because it will try to use cert bundle to fix it.
+	if certChains, err := leafCert.Verify(opts); err == nil {
+		return certChains[0], nil
 	}
-	return append(originalCerts, certBundle[parentCertIndex:]...), nil
+
+	// if the original certificates are not enough for generating the chain,
+	// try to use the certificate bundle.
+	for _, cert := range certBundle {
+		if bytes.Equal(cert.RawIssuer, cert.RawSubject) {
+			rootPool.AddCert(cert)
+		} else {
+			intermediatePool.AddCert(cert)
+		}
+	}
+	certChains, err := leafCert.Verify(opts)
+	if err != nil {
+		return nil, fmt.Errorf("cannot merge the certificate chain by the certificate bundle. error: %w", err)
+	}
+	return certChains[0], nil
+}
+
+// isValidFileName checks if a file name is cross-platform compatible
+func isValidFileName(fileName string) bool {
+	return regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`).MatchString(fileName)
 }

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/crypto/pkcs12"
 )
 
+// CertBundleKey defines the key name for the path of a certificate bundle file
+// passing through pluginConfig
 const CertBundleKey = "ca_certs"
 
 func parsePEM(data []byte) ([]*x509.Certificate, error) {

--- a/internal/crypto/cert.go
+++ b/internal/crypto/cert.go
@@ -10,12 +10,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"golang.org/x/crypto/pkcs12"
 )
 
-const certBundleKey = "certbundle"
+const certBundleKey = "ca_certs"
 
 func parsePEM(data []byte) ([]*x509.Certificate, error) {
 	var certs []*x509.Certificate
@@ -83,7 +82,6 @@ func MergeCertificateChain(pluginConfig map[string]string, originalCerts []*x509
 	}
 
 	// validate certificate bundle path
-	certBundlePath = strings.Trim(certBundlePath, " ")
 	basename := filepath.Base(certBundlePath)
 	if !isValidFileName(basename) {
 		return nil, fmt.Errorf("the filename of certificate bundle path is not cross-platform compatible. filename: %s", basename)

--- a/internal/signature/signer.go
+++ b/internal/signature/signer.go
@@ -75,13 +75,13 @@ func Sign(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.Gene
 	if err != nil {
 		return nil, requestErr(err)
 	}
-	// complete the cert chain by cert bundle from plugin configuration
-	completeCertChain, err := cert.CompleteCertificateChain(req.PluginConfig, certs)
+	// merged the cert chain by cert bundle from plugin configuration
+	mergedCertChain, err := cert.MergeCertificateChain(req.PluginConfig, certs)
 	if err != nil {
 		return nil, requestErr(err)
 	}
-	rawCertChain := make([][]byte, 0, len(completeCertChain))
-	for _, cert := range completeCertChain {
+	rawCertChain := make([][]byte, 0, len(mergedCertChain))
+	for _, cert := range mergedCertChain {
 		rawCertChain = append(rawCertChain, cert.Raw)
 	}
 

--- a/internal/signature/signer.go
+++ b/internal/signature/signer.go
@@ -85,7 +85,7 @@ func Sign(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.Gene
 			return nil, fmt.Errorf("failed to build a certificate chain using certificates fetched from AKV because %w. Try again with a certificate bundle file (including intermediate and root certificates) in PEM format through pluginConfig with `ca_certs` as key name and file path as value", err)
 		}
 		if validCertChain, err = cert.MergeCertificateChain(certBundlePath, certs); err != nil {
-			return nil, requestErr(err)
+			return nil, fmt.Errorf("failed to build a certificate chain with certificate bundle because %w", err)
 		}
 	}
 

--- a/internal/signature/signer.go
+++ b/internal/signature/signer.go
@@ -82,7 +82,7 @@ func Sign(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.Gene
 		// try to build cert chain with ca_certs of pluginConfig
 		certBundlePath, ok := req.PluginConfig[cert.CertBundleKey]
 		if !ok {
-			return nil, errors.New("the certificates fetched from AKV are not enough to build a certificate chain. Please provide a path of a certificate bundle file (including intermediate and root certificates) in PEM format through pluginConfig with `ca_certs` as the key name")
+			return nil, fmt.Errorf("failed to build a certificate chain using certificates fetched from AKV with error: %w. Try again with a certificate bundle file (including intermediate and root certificates) in PEM format through pluginConfig with `ca_certs` as key name and file path as value", err)
 		}
 		if validCertChain, err = cert.MergeCertificateChain(certBundlePath, certs); err != nil {
 			return nil, requestErr(err)

--- a/internal/signature/signer.go
+++ b/internal/signature/signer.go
@@ -82,7 +82,7 @@ func Sign(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.Gene
 		// try to build cert chain with ca_certs of pluginConfig
 		certBundlePath, ok := req.PluginConfig[cert.CertBundleKey]
 		if !ok {
-			return nil, fmt.Errorf("failed to build a certificate chain using certificates fetched from AKV with error: %w. Try again with a certificate bundle file (including intermediate and root certificates) in PEM format through pluginConfig with `ca_certs` as key name and file path as value", err)
+			return nil, fmt.Errorf("failed to build a certificate chain using certificates fetched from AKV because %w. Try again with a certificate bundle file (including intermediate and root certificates) in PEM format through pluginConfig with `ca_certs` as key name and file path as value", err)
 		}
 		if validCertChain, err = cert.MergeCertificateChain(certBundlePath, certs); err != nil {
 			return nil, requestErr(err)


### PR DESCRIPTION
Removed unnessary error message wrapping.

Previous error returned:
>failed to sign payload: failed to build a certificate chain using certificates fetched from AKV with error: failed to validate certificate chain. error: x509: certificate signed by unknown authority. Try again with a certificate bundle file (including intermediate and root certificates) in PEM format through pluginConfig with `ca_certs` as key name and file path as value

Current error returned:
> failed to build a certificate chain using certificates fetched from AKV because x509: certificate signed by unknown authority. Try again with a certificate bundle file (including intermediate and root certificates) in PEM format through pluginConfig with `ca_certs` as key name and file path as value

For those error message wrapping for debugging, we should make them as less as possible. User only want to know how to fix the error, wrapped messages are for developer.

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>