### PR TITLE
fix: check command before read input

### DIFF
--- a/Notation.Plugin.AzureKeyVault.Tests/ProgramTests.cs
+++ b/Notation.Plugin.AzureKeyVault.Tests/ProgramTests.cs
@@ -61,8 +61,6 @@ namespace Notation.Plugin.AzureKeyVault.Tests
             {
                 Console.SetOut(sw);
 
-                // We would ideally mock the input for describe-key and generate-signature
-                // as they expect inputs from PluginIO.ReadInput(). However, that is not covered in this example.
                 await Program.ExecuteAsync(args);
 
                 var output = sw.ToString();
@@ -83,8 +81,6 @@ namespace Notation.Plugin.AzureKeyVault.Tests
                 Console.SetOut(sw);
                 Console.SetIn(new StringReader(""));
 
-                // We would ideally mock the input for describe-key and generate-signature
-                // as they expect inputs from PluginIO.ReadInput(). However, that is not covered in this example.
                 await Assert.ThrowsAsync<ValidationException>(() => Program.ExecuteAsync(args));
             }
         }

--- a/Notation.Plugin.AzureKeyVault.Tests/ProgramTests.cs
+++ b/Notation.Plugin.AzureKeyVault.Tests/ProgramTests.cs
@@ -1,0 +1,92 @@
+using Xunit;
+using Moq;
+using Notation.Plugin.AzureKeyVault.Command;
+using Notation.Plugin.Protocol;
+using System.IO;
+using System.Threading.Tasks;
+using System;
+
+namespace Notation.Plugin.AzureKeyVault.Tests
+{
+    public class ProgramTests
+    {
+        [Fact]
+        public async Task Main_ExecutesWithoutException()
+        {
+            var args = new[] { "get-plugin-metadata" };
+
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+
+                await Program.Main(args);
+
+                Assert.NotEmpty(sw.ToString());
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ThrowsOnInvalidCommand()
+        {
+            var args = new[] { "invalid-command" };
+
+            await Assert.ThrowsAsync<ValidationException>(() => Program.ExecuteAsync(args));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ReturnsHelpOnNoArgs()
+        {
+            var args = new string[0];
+
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+
+                await Program.ExecuteAsync(args);
+
+                var output = sw.ToString();
+
+                Assert.Contains("Usage:", output);
+                Assert.Contains("Commands:", output);
+                Assert.Contains("Documentation:", output);
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_HandlesValidCommands()
+        {
+            var args = new[] { "get-plugin-metadata" };
+
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+
+                // We would ideally mock the input for describe-key and generate-signature
+                // as they expect inputs from PluginIO.ReadInput(). However, that is not covered in this example.
+                await Program.ExecuteAsync(args);
+
+                var output = sw.ToString();
+
+                Assert.NotEmpty(output);
+            }
+        }
+
+        [Theory]
+        [InlineData("describe-key")]
+        [InlineData("generate-signature")]
+        public async Task ExecuteAsync_HandlesInvalidCommands(string command)
+        {
+            var args = new[] { command };
+
+            using (var sw = new StringWriter())
+            {
+                Console.SetOut(sw);
+                Console.SetIn(new StringReader(""));
+
+                // We would ideally mock the input for describe-key and generate-signature
+                // as they expect inputs from PluginIO.ReadInput(). However, that is not covered in this example.
+                await Assert.ThrowsAsync<ValidationException>(() => Program.ExecuteAsync(args));
+            }
+        }
+    }
+}

--- a/Notation.Plugin.AzureKeyVault/Program.cs
+++ b/Notation.Plugin.AzureKeyVault/Program.cs
@@ -3,9 +3,9 @@ using Notation.Plugin.Protocol;
 
 namespace Notation.Plugin.AzureKeyVault
 {
-    class Program
+    public class Program
     {
-        static async Task Main(string[] args)
+        public static async Task Main(string[] args)
         {
             try
             {
@@ -23,7 +23,7 @@ namespace Notation.Plugin.AzureKeyVault
             }
         }
 
-        static async Task ExecuteAsync(string[] args)
+        public static async Task ExecuteAsync(string[] args)
         {
             if (args.Length < 1)
             {

--- a/Notation.Plugin.AzureKeyVault/Program.cs
+++ b/Notation.Plugin.AzureKeyVault/Program.cs
@@ -31,9 +31,6 @@ namespace Notation.Plugin.AzureKeyVault
                 return;
             }
 
-            // read the input
-            var inputJson = PluginIO.ReadInput();
-
             IPluginCommand? cmd = null;
             switch (args[0])
             {
@@ -41,10 +38,10 @@ namespace Notation.Plugin.AzureKeyVault
                     cmd = new GetPluginMetadata();
                     break;
                 case "describe-key":
-                    cmd = new DescribeKey(inputJson);
+                    cmd = new DescribeKey(PluginIO.ReadInput());
                     break;
                 case "generate-signature":
-                    cmd = new GenerateSignature(inputJson);
+                    cmd = new GenerateSignature(PluginIO.ReadInput());
                     break;
                 default:
                     throw new ValidationException($"Invalid command: {args[0]}");


### PR DESCRIPTION
Fix:
- before the fixing, the plugin needs to read the input before check the command name
- after the fixing, the plugin check the command name before reading the input

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>