### PR TITLE
fix: remove X509Chain.Build to avoid compatibility issue

### DIFF
--- a/Notation.Plugin.AzureKeyVault.Tests/Certificate/CertificateChainTests.cs
+++ b/Notation.Plugin.AzureKeyVault.Tests/Certificate/CertificateChainTests.cs
@@ -22,38 +22,5 @@ namespace Notation.Plugin.AzureKeyVault.Certificate.Tests
             Assert.NotNull(certificateChain);
             Assert.True(certificateChain.Count > 0);
         }
-
-        [Fact]
-        public void Build_WithInvalidLeafCertificate_ThrowsValidationException()
-        {
-            // Arrange
-            X509Certificate2 expiredLeafCert = new X509Certificate2(Path.Combine(Directory.GetCurrentDirectory(), "TestData", "expired_leaf.crt"));
-            X509Certificate2Collection certificateBundle = new X509Certificate2Collection();
-
-            // Act and Assert
-            Assert.Throws<ValidationException>(() => CertificateChain.Build(expiredLeafCert, certificateBundle));
-        }
-
-        [Fact]
-        public void Build_WithIncompleteCertificateBundle_ThrowsValidationException()
-        {
-            // Arrange
-            X509Certificate2 invalidLeafCert = new X509Certificate2(Path.Combine(Directory.GetCurrentDirectory(), "TestData", "leaf.crt"));
-            X509Certificate2Collection certificateBundle = new X509Certificate2Collection();
-
-            // Act and Assert
-            Assert.Throws<ValidationException>(() => CertificateChain.Build(invalidLeafCert, certificateBundle));
-        }
-
-        [Fact]
-        public void Build_WithValidLeafAndUnmatchableCertificateBundle_BuildsCertificateChain()
-        {
-            // Arrange
-            X509Certificate2 leafCert = new X509Certificate2(Path.Combine(Directory.GetCurrentDirectory(), "TestData", "leaf.crt"));
-            X509Certificate2Collection certificateBundle = CertificateBundle.Create(Path.Combine(Directory.GetCurrentDirectory(), "TestData", "unmatchable_root.pem"));
-
-            // Act and Assert
-            Assert.Throws<ValidationException>(() => CertificateChain.Build(leafCert, certificateBundle));
-        }
     }
 }

--- a/Notation.Plugin.AzureKeyVault/Certificate/CertificateChain.cs
+++ b/Notation.Plugin.AzureKeyVault/Certificate/CertificateChain.cs
@@ -13,45 +13,16 @@ namespace Notation.Plugin.AzureKeyVault.Certificate
         /// Build a certificate chain from a leaf certificate and a 
         /// certificate bundle.
         /// 
+        /// Note: the method doen't check the validity of the chain.
         /// <param name="certificateBundle">The certificate bundle.</param>
         /// <param name="leafCert">The leaf certificate.</param>
         /// <returns>A list of raw certificates in a chain.</returns>
         /// </summary>
         public static List<byte[]> Build(X509Certificate2 leafCert, X509Certificate2Collection certificateBundle)
         {
-            X509Chain chain = new X509Chain();
-            chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
-            chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-            chain.ChainPolicy.CustomTrustStore.AddRange(certificateBundle);
-
-            try
-            {
-                bool isValid = chain.Build(leafCert);
-                if (!isValid)
-                {
-                    throw new ValidationException("Certificate is invalid");
-                }
-            }
-            catch (CryptographicException e)
-            {
-                throw new ValidationException($"Failed to build the X509 chain. {e.Message} The certificate bundle is unreadable. Please ensure the certificate bundle matches the specific certifcate.");
-            }
-
-            foreach (X509ChainStatus status in chain.ChainStatus)
-            {
-                if (status.Status == X509ChainStatusFlags.PartialChain)
-                {
-                    throw new ValidationException("Failed to build the X509 chain up to the root certificate. The provided certificate bundle either does not match or does not contain enough certificates to build a complete chain. To resolve this issue, provide the intermediate and root certificates by passing the certificate bundle file's path to the `ca_certs` key in the pluginConfig");
-                }
-
-                if (status.Status != X509ChainStatusFlags.NoError && status.Status != X509ChainStatusFlags.UntrustedRoot)
-                {
-                    throw new ValidationException($"Failed to build the X509 chain due to {status.StatusInformation}");
-                }
-            }
-
-            return chain.ChainElements.Select(x => x.Certificate.RawData).ToList();
+            X509Certificate2Collection chain = new X509Certificate2Collection(leafCert);
+            chain.AddRange(certificateBundle);
+            return chain.Select(x => x.RawData).ToList();
         }
     }
 }


### PR DESCRIPTION
After the PR, the plugin will not check the certificate chain integrity.

Resolves #116 
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>