### PR TITLE
doc: update ca signed workflow

### DIFF
--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -101,7 +101,7 @@
    ```
 9. Sign the image with an external certificate bundle (`$certBundlePath`) in PEM format. You may fetch the certificate bundle from your CA official site.
 
-   Ensure that the certificates in the bundle are correctly ordered: starting from the intermediate certificate that signed the leaf certificate, and ending with the root certificate. 
+   Ensure that the certificates in the bundle are correctly ordered: starting from the intermediate certificate that signed the leaf certificate, and ending with the root certificate.
    They must be concatenated such that each certificate directly validates the preceding one. The following example features two certificates: an intermediate and a root certificate, but your certificate chain may include more or fewer.
    ```pem
    -----BEGIN CERTIFICATE-----

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -99,8 +99,17 @@
    docker tag hello-world:latest $server/hello-world:v1
    docker push $server/hello-world:v1
    ```
-9. Sign the image with an external certificate bundle (`$certBundlePath`) including the in PEM format. Check that the certificates in the certificate bundle are arranged in the correct order: starting from the first intermediate certificate that signed the leaf certificate and ending with the root certificate.
-   You may fetch the certificate bundle from your CA official site.
+9. Sign the image with an external certificate bundle (`$certBundlePath`) in PEM format. You may fetch the certificate bundle from your CA official site.
+
+   Ensure that the certificates in the bundle are correctly ordered: starting from the intermediate certificate that signed the leaf certificate, and ending with the root certificate. They must be concatenated such that each certificate directly validates the preceding one. The following example features two certificates: an intermediate and a root certificate, but your certificate chain may include more or fewer.
+   ```
+   -----BEGIN CERTIFICATE-----
+   Base64–encoded intermediate certificate
+   -----END CERTIFICATE-----
+   -----BEGIN CERTIFICATE-----
+   Base64–encoded root certificate
+   -----END CERTIFICATE-----
+   ```
    > **Note** If you have generated the certificate with `openssl` according to the above steps, the certificate bundle is the root certificate `ca.crt`.
    ```sh
    notation key add --plugin azure-kv --id $keyID akv-key --default

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -101,8 +101,9 @@
    ```
 9. Sign the image with an external certificate bundle (`$certBundlePath`) in PEM format. You may fetch the certificate bundle from your CA official site.
 
-   Ensure that the certificates in the bundle are correctly ordered: starting from the intermediate certificate that signed the leaf certificate, and ending with the root certificate. They must be concatenated such that each certificate directly validates the preceding one. The following example features two certificates: an intermediate and a root certificate, but your certificate chain may include more or fewer.
-   ```
+   Ensure that the certificates in the bundle are correctly ordered: starting from the intermediate certificate that signed the leaf certificate, and ending with the root certificate. 
+   They must be concatenated such that each certificate directly validates the preceding one. The following example features two certificates: an intermediate and a root certificate, but your certificate chain may include more or fewer.
+   ```pem
    -----BEGIN CERTIFICATE-----
    Base64–encoded intermediate certificate
    -----END CERTIFICATE-----

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -99,9 +99,8 @@
    docker tag hello-world:latest $server/hello-world:v1
    docker push $server/hello-world:v1
    ```
-9. Sign the image with an external certificate bundle (`$certBundlePath`) including the intermediate certificates and a root certificate in PEM format. You may fetch the certificate bundle from your CA official site.
-   > **Note** Check that the certificates in the PEM certificate bundle are arranged in the correct order: starting from the first intermediate certificate that signed the leaf certificate and ending with the root certificate.
-   
+9. Sign the image with an external certificate bundle (`$certBundlePath`) including the in PEM format. Check that the certificates in the certificate bundle are arranged in the correct order: starting from the first intermediate certificate that signed the leaf certificate and ending with the root certificate.
+   You may fetch the certificate bundle from your CA official site.
    > **Note** If you have generated the certificate with `openssl` according to the above steps, the certificate bundle is the root certificate `ca.crt`.
    ```sh
    notation key add --plugin azure-kv --id $keyID akv-key --default

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -100,8 +100,8 @@
    docker push $server/hello-world:v1
    ```
 9. Sign the image with an external certificate bundle (`$certBundlePath`) including the intermediate certificates and a root certificate in PEM format. You may fetch the certificate bundle from your CA official site.
-   > **Note** Check that the certificates in the PEM file are arranged in the correct order: starting from the first intermediate certificate that signed the leaf certificate and ending with the root certificate.
-
+   > **Note** Check that the certificates in the PEM certificate bundle are arranged in the correct order: starting from the first intermediate certificate that signed the leaf certificate and ending with the root certificate.
+   
    > **Note** If you have generated the certificate with `openssl` according to the above steps, the certificate bundle is the root certificate `ca.crt`.
    ```sh
    notation key add --plugin azure-kv --id $keyID akv-key --default

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -99,7 +99,7 @@
    docker tag hello-world:latest $server/hello-world:v1
    docker push $server/hello-world:v1
    ```
-9. Sign the image with an external certificate bundle (`$certBundlePath`) including the intermediate certificates and a root certificate in PEM format. You may fetch the certificate bundle from your CA official site.
+9. Sign the image with an external certificate bundle (`$certBundlePath`) including the intermediate certificates and a root certificate in PEM format. Check that the certificates in the PEM file are arranged in the correct order: starting from the first intermediate certificate that signed the leaf certificate and ending with the root certificate. You may fetch the certificate bundle from your CA official site.
    > **Note** If you have generated the certificate with `openssl` according to the above steps, the certificate bundle is the root certificate `ca.crt`.
    ```sh
    notation key add --plugin azure-kv --id $keyID akv-key --default

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -99,7 +99,9 @@
    docker tag hello-world:latest $server/hello-world:v1
    docker push $server/hello-world:v1
    ```
-9. Sign the image with an external certificate bundle (`$certBundlePath`) including the intermediate certificates and a root certificate in PEM format. Check that the certificates in the PEM file are arranged in the correct order: starting from the first intermediate certificate that signed the leaf certificate and ending with the root certificate. You may fetch the certificate bundle from your CA official site.
+9. Sign the image with an external certificate bundle (`$certBundlePath`) including the intermediate certificates and a root certificate in PEM format. You may fetch the certificate bundle from your CA official site.
+   > **Note** Check that the certificates in the PEM file are arranged in the correct order: starting from the first intermediate certificate that signed the leaf certificate and ending with the root certificate.
+
    > **Note** If you have generated the certificate with `openssl` according to the above steps, the certificate bundle is the root certificate `ca.crt`.
    ```sh
    notation key add --plugin azure-kv --id $keyID akv-key --default


### PR DESCRIPTION
Update:
- With the removal of the automatic certificate chain arrangement feature in update #116, you'll now need to manually create a valid certificate bundle by following the guide.

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>