### PR TITLE
feat: add self_signed pluginConfig

### DIFF
--- a/Notation.Plugin.AzureKeyVault.Tests/Certificate/CertificateBundleTests.cs
+++ b/Notation.Plugin.AzureKeyVault.Tests/Certificate/CertificateBundleTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
+using Notation.Plugin.Protocol;
 using Xunit;
 
 namespace Notation.Plugin.AzureKeyVault.Certificate.Tests
@@ -18,6 +19,16 @@ namespace Notation.Plugin.AzureKeyVault.Certificate.Tests
             // Assert
             Assert.NotNull(certificates);
             Assert.True(certificates.Count > 0);
+        }
+
+        [Fact]
+        public void Create_ThrowsPluginException_WhenPemFileIsEmpty()
+        {
+            // Arrange
+            var pemPath = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "empty.pem");
+
+            // Act & Assert
+            Assert.Throws<PluginException>(() => CertificateBundle.Create(pemPath));
         }
     }
 }

--- a/Notation.Plugin.AzureKeyVault.Tests/Command/GenerateSignatureTests.cs
+++ b/Notation.Plugin.AzureKeyVault.Tests/Command/GenerateSignatureTests.cs
@@ -126,7 +126,7 @@ namespace Notation.Plugin.AzureKeyVault.Command.Tests
             var request = new GenerateSignatureRequest(
                 contractVersion: "1.0",
                 keyId: keyId,
-                pluginConfig: new Dictionary<string, string>(){},
+                pluginConfig: new Dictionary<string, string>() { },
                 keySpec: expectedKeySpec,
                 hashAlgorithm: "SHA-256",
                 payload: Encoding.UTF8.GetBytes("Cg=="));
@@ -166,8 +166,9 @@ namespace Notation.Plugin.AzureKeyVault.Command.Tests
         }
 
         [Fact]
-        public void RunAsync_NoSecertsGetPermission(){
-             // Arrange
+        public void RunAsync_NoSecertsGetPermission()
+        {
+            // Arrange
             var keyId = "https://testvault.vault.azure.net/keys/testkey/123";
             var expectedKeySpec = "RSA-2048";
             var mockSignature = new byte[] { 0x01, 0x02, 0x03, 0x04 };
@@ -181,7 +182,7 @@ namespace Notation.Plugin.AzureKeyVault.Command.Tests
             var request = new GenerateSignatureRequest(
                 contractVersion: "1.0",
                 keyId: keyId,
-                pluginConfig: new Dictionary<string, string>(){},
+                pluginConfig: new Dictionary<string, string>() { },
                 keySpec: expectedKeySpec,
                 hashAlgorithm: "SHA-256",
                 payload: Encoding.UTF8.GetBytes("Cg=="));
@@ -192,8 +193,9 @@ namespace Notation.Plugin.AzureKeyVault.Command.Tests
         }
 
         [Fact]
-        public void RunAsync_OtherRequestFailedException(){
-             // Arrange
+        public void RunAsync_OtherRequestFailedException()
+        {
+            // Arrange
             var keyId = "https://testvault.vault.azure.net/keys/testkey/123";
             var expectedKeySpec = "RSA-2048";
             var mockSignature = new byte[] { 0x01, 0x02, 0x03, 0x04 };
@@ -207,7 +209,7 @@ namespace Notation.Plugin.AzureKeyVault.Command.Tests
             var request = new GenerateSignatureRequest(
                 contractVersion: "1.0",
                 keyId: keyId,
-                pluginConfig: new Dictionary<string, string>(){},
+                pluginConfig: new Dictionary<string, string>() { },
                 keySpec: expectedKeySpec,
                 hashAlgorithm: "SHA-256",
                 payload: Encoding.UTF8.GetBytes("Cg=="));

--- a/Notation.Plugin.AzureKeyVault/Certificate/CertificateBundle.cs
+++ b/Notation.Plugin.AzureKeyVault/Certificate/CertificateBundle.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography.X509Certificates;
+using Notation.Plugin.Protocol;
 
 namespace Notation.Plugin.AzureKeyVault.Certificate
 {
@@ -14,6 +15,10 @@ namespace Notation.Plugin.AzureKeyVault.Certificate
         {
             var certificates = new X509Certificate2Collection();
             certificates.ImportFromPemFile(pemFilePath);
+            if (certificates.Count == 0)
+            {
+                throw new PluginException($"No certificate found in {pemFilePath}");
+            }
             return certificates;
         }
     }

--- a/Notation.Plugin.AzureKeyVault/Command/GenerateSignature.cs
+++ b/Notation.Plugin.AzureKeyVault/Command/GenerateSignature.cs
@@ -66,7 +66,8 @@ namespace Notation.Plugin.AzureKeyVault.Command
                 }
                 catch (Azure.RequestFailedException ex)
                 {
-                    if (ex.Message.Contains("does not have secrets get permission")){
+                    if (ex.Message.Contains("does not have secrets get permission"))
+                    {
                         throw new PluginException("The plugin does not have secrets get permission. Please grant the permission to the credential associated with the plugin or specify the file path of the certificate chain bundle through the `ca_certs` parameter in the plugin config.");
                     }
                     throw;

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -114,7 +114,7 @@
    > **Note** If you have generated the certificate with `openssl` according to the above steps, the certificate bundle is the root certificate `ca.crt`.
    ```sh
    notation key add --plugin azure-kv --id $keyID akv-key --default
-   notation sign $server/hello-world:v1 --plugin-config=ca_certs=$certBundlePath
+   notation sign $server/hello-world:v1
    ```
 
    The following example output shows the artifact is successfully signed.

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -1,7 +1,7 @@
 # Sign and verify an artifact with a certificate signed by a trusted CA in Azure Key Vault
 > **Note** The following guide can be executed on Linux bash, macOS Zsh and Windows WSL
 1. [Install the Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
-2. Log in to Azure with Azure CLI, set the subscription and make sure the `GetCertificate` and `Sign` permission have been granted to your role:
+2. Log in to Azure with Azure CLI, set the subscription and make sure the `GetCertificates`, `GetSecrets` and `Sign` permission for Azure Key Vault have been granted to your role:
    ```sh
    az login
    az account set --subscription $subscriptionID

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -1,7 +1,7 @@
 # Sign and verify an artifact with a certificate signed by a trusted CA in Azure Key Vault
 > **Note** The following guide can be executed on Linux bash, macOS Zsh and Windows WSL
 1. [Install the Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
-2. Log in to Azure with Azure CLI, set the subscription and make sure the `GetCertificates`, `GetSecrets` and `Sign` permission for Azure Key Vault have been granted to your role:
+2. Log in to Azure with Azure CLI, set the subscription and make sure the `GetCertificate` and `Sign` permission have been granted to your role:
    ```sh
    az login
    az account set --subscription $subscriptionID
@@ -114,7 +114,7 @@
    > **Note** If you have generated the certificate with `openssl` according to the above steps, the certificate bundle is the root certificate `ca.crt`.
    ```sh
    notation key add --plugin azure-kv --id $keyID akv-key --default
-   notation sign $server/hello-world:v1
+   notation sign $server/hello-world:v1 --plugin-config=ca_certs=$certBundlePath
    ```
 
    The following example output shows the artifact is successfully signed.

--- a/docs/self-signed-workflow.md
+++ b/docs/self-signed-workflow.md
@@ -1,9 +1,9 @@
 # Sign and verify an artifact with a self-signed Azure Key Vault certificate
 > **Warning** Using self-signed certificates are intended for development and testing. Outside of development and testing, a certificate from a trusted CA is recommended.
 >
-> **Note** The following guide can be executed on Linux bash, macOS Zsh and Windows WSL.
+> **Note** The following guide can be executed on Linux bash, macOS Zsh and Windows WSL
 1. [Install the Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
-2. Log in using the Azure CLI, set the subscription, and confirm the `GetCertificates` and `Sign` permission for Azure Key Vault have been granted to your role:
+2. Log in using the Azure CLI, set the subscription, and confirm the `GetCertificate` and `Sign` permission have been granted to your role:
    ```sh
    az login
    az account set --subscription $subscriptionID

--- a/docs/self-signed-workflow.md
+++ b/docs/self-signed-workflow.md
@@ -3,7 +3,7 @@
 
 > **Note** The following guide can be executed on Linux bash, macOS Zsh and Windows WSL
 1. [Install the Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
-2. Log in using the Azure CLI, set the subscription, and confirm the `GetCertificate` and `Sign` permission have been granted to your role:
+2. Log in using the Azure CLI, set the subscription, and confirm the `GetCertificates`, `GetSecrets` and `Sign` permission for Azure Key Vault have been granted to your role:
    ```sh
    az login
    az account set --subscription $subscriptionID

--- a/docs/self-signed-workflow.md
+++ b/docs/self-signed-workflow.md
@@ -75,12 +75,12 @@
    ```
 7. Sign the container image with Notation:
    ```sh
-   notation key add --plugin azure-kv --id $keyID akv-key --default --plugin-config=self_signed=true
+   notation key add --plugin azure-kv --id $keyID akv-key --default --plugin-config self_signed=true
    notation sign $server/hello-world:v1
    ```
 
    The following example output shows the artifact is successfully signed.
-   ```sh
+   ```text
    Warning: Always sign the artifact using digest(@sha256:...) rather than a tag(:v1) because tags are mutable and a tag reference can point to a different artifact than the one signed.
    Successfully signed notation.azurecr.io/hello-world@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4
    ```
@@ -123,7 +123,7 @@
    notation verify $server/hello-world:v1
    ```
    The following output shows the artifact is successfully verified.
-   ```sh
+   ```text
    Warning: Always verify the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
    Successfully verified signature for notation.azurecr.io/hello-world@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4
    ```

--- a/docs/self-signed-workflow.md
+++ b/docs/self-signed-workflow.md
@@ -3,7 +3,7 @@
 >
 > **Note** The following guide can be executed on Linux bash, macOS Zsh and Windows WSL.
 1. [Install the Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
-2. Log in using the Azure CLI, set the subscription, and confirm the `GetCertificates`, `GetSecrets` and `Sign` permission for Azure Key Vault have been granted to your role:
+2. Log in using the Azure CLI, set the subscription, and confirm the `GetCertificates` and `Sign` permission for Azure Key Vault have been granted to your role:
    ```sh
    az login
    az account set --subscription $subscriptionID
@@ -75,7 +75,7 @@
    ```
 7. Sign the container image with Notation:
    ```sh
-   notation key add --plugin azure-kv --id $keyID akv-key --default
+   notation key add --plugin azure-kv --id $keyID akv-key --default --plugin-config=self_signed=true
    notation sign $server/hello-world:v1
    ```
 

--- a/docs/self-signed-workflow.md
+++ b/docs/self-signed-workflow.md
@@ -1,7 +1,7 @@
 # Sign and verify an artifact with a self-signed Azure Key Vault certificate
 > **Warning** Using self-signed certificates are intended for development and testing. Outside of development and testing, a certificate from a trusted CA is recommended.
-
-> **Note** The following guide can be executed on Linux bash, macOS Zsh and Windows WSL
+>
+> **Note** The following guide can be executed on Linux bash, macOS Zsh and Windows WSL.
 1. [Install the Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
 2. Log in using the Azure CLI, set the subscription, and confirm the `GetCertificates`, `GetSecrets` and `Sign` permission for Azure Key Vault have been granted to your role:
    ```sh
@@ -80,7 +80,7 @@
    ```
 
    The following example output shows the artifact is successfully signed.
-   ```
+   ```sh
    Warning: Always sign the artifact using digest(@sha256:...) rather than a tag(:v1) because tags are mutable and a tag reference can point to a different artifact than the one signed.
    Successfully signed notation.azurecr.io/hello-world@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4
    ```
@@ -123,7 +123,7 @@
    notation verify $server/hello-world:v1
    ```
    The following output shows the artifact is successfully verified.
-   ```
+   ```sh
    Warning: Always verify the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
    Successfully verified signature for notation.azurecr.io/hello-world@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4
    ```


### PR DESCRIPTION
Feat:
- added self_signed parameter in the pluginConfig for self-signed certificate (`Certificates Get` permission)

Fix:
- removed as_secert pluginConfig
- secerts get is the default behavior when `self_signed` and `ca_certs` are not set (`Secrets Get` permission)
- added a message to remind user to enable secrets get permission
- raise exception when the ca_certs is empty

Parameters logic:
- self_signed is true && ca_certs=/path/to/cacerts **==>** exception
- self_signed is true && ca_certs is null or empty **==>** get self-signed certificate with `Certificates Get` permission
- self_signed is false or not set && ca_certs=/path/to/cacerts **==>** get leaf certificate with `Certificates Get` permission and read the certificate bundle from file
- self_signed is false or not set && ca_certs is not set or empty **==>**  get certificate chain with `Secrets Get` permission

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>

