### PR TITLE
doc: update set policy

### DIFF
--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -26,7 +26,7 @@
    ```sh
    userId=$(az ad signed-in-user show --query id -o tsv)
    az keyvault set-policy -n "$keyVault" \
-      --certificate-permissions create get list\
+      --certificate-permissions create get list \
       --key-permissions sign \
       --secret-permissions get \
       --object-id "$userId"

--- a/docs/ca-signed-workflow.md
+++ b/docs/ca-signed-workflow.md
@@ -26,9 +26,10 @@
    ```sh
    userId=$(az ad signed-in-user show --query id -o tsv)
    az keyvault set-policy -n "$keyVault" \
+      --certificate-permissions create get list\
       --key-permissions sign \
       --secret-permissions get \
-      --upn "$userId"
+      --object-id "$userId"
    ```
    > [!NOTE]
    > The script assigns the permission to the current user, and you can also assign the permission to your [managed identity](https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) or [service principal](https://learn.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals?tabs=browser).


### PR DESCRIPTION
The guide environment is local comand line with az logined admin account. We need certificate create and get permission to create the certificate and get the key id. However, for production deployment, customer should use managed identity or service principal instead of admin account, which will be mentioned in Microsoft Learn official document.

Resolves #132 
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>