### PR TITLE
fix(ci): test and release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           name: ${{ matrix.runtime }}
           path: ${{ github.workspace }}/bin/artifacts
+          overwrite: true
           retention-days: 1
   release:
     name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
     name: E2E testing for Mariner container
     runs-on: ubuntu-latest
     needs: test
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     steps:
       - name: Check out code into the project directory
         uses: actions/checkout@v4


### PR DESCRIPTION
Fix:
- added check for `e2e-mariner-container` test to only run on PR from this repo
- enabled override for `actions/upload-artifact@v4`, which is a breaking change in v4

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>