### PR TITLE
fix: dependabot exception when parsing .csproj

### DIFF
--- a/Notation.Plugin.AzureKeyVault/Notation.Plugin.AzureKeyVault.csproj
+++ b/Notation.Plugin.AzureKeyVault/Notation.Plugin.AzureKeyVault.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <Target Name="GenerateBuildMetadata" BeforeTargets="CoreCompile">
-   <WriteLinesToFile
+    <WriteLinesToFile
       File="$(IntermediateOutputPath)\GetPluginMetadata.g.cs"
       Lines="
         namespace Notation.Plugin.AzureKeyVault.Command

--- a/Notation.Plugin.AzureKeyVault/Notation.Plugin.AzureKeyVault.csproj
+++ b/Notation.Plugin.AzureKeyVault/Notation.Plugin.AzureKeyVault.csproj
@@ -34,8 +34,8 @@
             {
                 static GetPluginMetadata()
                 {
-                    Version = &quot;$(Version)&quot;;
-                    CommitHash = &quot;$(CommitHash)&quot;;
+                    Version = &quot;$(Version)&quot;%3b
+                    CommitHash = &quot;$(CommitHash)&quot;%3b
                 }
             }
         }"

--- a/Notation.Plugin.AzureKeyVault/Notation.Plugin.AzureKeyVault.csproj
+++ b/Notation.Plugin.AzureKeyVault/Notation.Plugin.AzureKeyVault.csproj
@@ -25,24 +25,24 @@
   </ItemGroup>
 
   <Target Name="GenerateBuildMetadata" BeforeTargets="CoreCompile">
-    <WriteLinesToFile
-      File="$(IntermediateOutputPath)\GetPluginMetadta.g.cs"
-      Lines='
+   <WriteLinesToFile
+      File="$(IntermediateOutputPath)\GetPluginMetadata.g.cs"
+      Lines="
         namespace Notation.Plugin.AzureKeyVault.Command
         {
             public partial class GetPluginMetadata
             {
                 static GetPluginMetadata()
                 {
-                    Version = "$(Version)"%3b
-                    CommitHash = "$(CommitHash)"%3b
+                    Version = &quot;$(Version)&quot;;
+                    CommitHash = &quot;$(CommitHash)&quot;;
                 }
             }
-        }'
+        }"
       Overwrite="true"
       WriteOnlyWhenDifferent="true" />
     <ItemGroup>
-      <Compile Include="$(IntermediateOutputPath)\GetPluginMetadta.g.cs" />
+      <Compile Include="$(IntermediateOutputPath)\GetPluginMetadata.g.cs" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Fix:
- dependabot was blocked by exception in Notation.Plugin.AzureKeyVault/Notation.Plugin.AzureKeyVault.csproj

Error log: https://github.com/Azure/notation-azure-kv/network/updates/815374970

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>