### PR TITLE
ci: improve reliability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,19 @@ jobs:
         config:
           - runtime: osx-x64
             build_args: ""
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - runtime: osx-arm64
             build_args: ""
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - runtime: linux-x64
             build_args: --enable-aot
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - runtime: linux-arm64
             build_args: --enable-aot
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - runtime: win-x64
             build_args: --enable-aot
-            os: windows-latest
+            os: windows-2022
     name: Build
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -91,7 +91,7 @@ jobs:
           retention-days: 1
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: macos_codesign
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             os: ubuntu-24.04
           - runtime: linux-arm64
             build_args: --enable-aot
-            os: ubuntu-24.04
+            os: ubuntu-24.04-arm
           - runtime: win-x64
             build_args: --enable-aot
             os: windows-2022
@@ -41,19 +41,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-      - name: Setup ARM64 Emulator
-        if: matrix.config.runtime == 'linux-arm64'
-        run: |
-          sudo dpkg --add-architecture arm64
-          sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
-          EOF'
-          sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
-          sudo sed -i -e 's/deb mirror/deb [arch=amd64] mirror/g' /etc/apt/sources.list
-          sudo apt update
-          sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
       - name: Build .NET project
         shell: bash
         run: python3 ./scripts/build.py "${GITHUB_REF_NAME}" ${{ matrix.config.runtime }} ${{ matrix.config.build_args }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           VALIDATE_SHELL_SHFMT: false
   test:
     name: Unit Testing and Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
@@ -126,51 +126,12 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_FEDERATED_TOKEN_FILE: ./federated_token
-  e2e-ubuntu-2404:
+  e2e-linux:
     name: E2E testing on Linux
-    runs-on: ubuntu-24.04
-    environment: E2E
-    needs: test
-    steps:
-      - name: Check out code into the project directory
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@v4
-        with:
-          name: linux-amd64-binary
-          path: ./bin/artifacts
-      - name: Run download server locally
-        run: |
-          nohup python3 -m http.server --directory ./bin/artifacts/ &
-
-          # prepare the environment variables for E2E
-          artifactName=notation-azure-kv_0.0.1_linux_amd64.tar.gz
-          checksum=$(shasum -a 256 "./bin/artifacts/$artifactName" | awk '{print $1}')
-          echo "pluginChecksum=$checksum" >> "$GITHUB_ENV"
-          echo "pluginDownloadURL=http://localhost:8000/$artifactName" >> "$GITHUB_ENV"
-      - name: Prepare container registry
-        run: |
-          docker run --name registry --rm -d -p 5000:5000 registry:2
-          docker pull hello-world:latest
-          docker tag hello-world:latest localhost:5000/hello-world:v1
-          docker push localhost:5000/hello-world:v1
-      - name: Azure login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: E2E testing
-        uses: ./test/e2e
-        with:
-          pluginDownloadURL: ${{ env.pluginDownloadURL }}
-          pluginChecksum: ${{ env.pluginChecksum }}
-  e2e-ubuntu-2204:
-    name: E2E testing on Linux
-    runs-on: ubuntu-22.04
-    environment: E2E
-    needs: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
     steps:
       - name: Check out code into the project directory
         uses: actions/checkout@v4
@@ -208,7 +169,10 @@ jobs:
           pluginChecksum: ${{ env.pluginChecksum }}
   e2e-windows:
     name: E2E testing on Windows
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022, windows-2025]
     environment: E2E
     needs: test
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,37 @@ jobs:
           name: darwin-amd64-binary
           path: ./bin/artifacts/notation-azure-kv_0.0.1_darwin_amd64.tar.gz
           retention-days: 1
+  test-arm:
+    name: Unit Testing and Build on ARM
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Check out code into the project directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run unit tests
+        run: make test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Build Linux Binary
+        run: |
+          # the binary will be used in E2E test
+          python3 ./scripts/build.py v0.0.1 linux-arm64 --enable-aot
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-arm64-binary
+          path: ./bin/artifacts/notation-azure-kv_0.0.1_linux_arm64.tar.gz
+          retention-days: 1
   e2e-mariner-container:
     name: E2E testing for Mariner container
     runs-on: ubuntu-latest
@@ -128,12 +159,20 @@ jobs:
           AZURE_FEDERATED_TOKEN_FILE: ./federated_token
   e2e-linux:
     name: E2E testing on Linux
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        config:
+          - os: ubuntu-24.04
+            arch: amd64
+          - os: ubuntu-22.04
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+          - os: ubuntu-22.04-arm
+            arch: arm64
     environment: E2E
-    needs: test
+    needs: [test, test-arm]
     steps:
       - name: Check out code into the project directory
         uses: actions/checkout@v4
@@ -141,14 +180,14 @@ jobs:
           fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
-          name: linux-amd64-binary
+          name: linux-${{ matrix.config.arch }}-binary
           path: ./bin/artifacts
       - name: Run download server locally
         run: |
           nohup python3 -m http.server --directory ./bin/artifacts/ &
 
           # prepare the environment variables for E2E
-          artifactName=notation-azure-kv_0.0.1_linux_amd64.tar.gz
+          artifactName=notation-azure-kv_0.0.1_linux_${{ matrix.config.arch }}.tar.gz
           checksum=$(shasum -a 256 "./bin/artifacts/$artifactName" | awk '{print $1}')
           echo "pluginChecksum=$checksum" >> "$GITHUB_ENV"
           echo "pluginDownloadURL=http://localhost:8000/$artifactName" >> "$GITHUB_ENV"
@@ -174,7 +213,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, windows-2022, windows-2025]
+        os: [windows-2022, windows-2025]
     environment: E2E
     needs: test
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
+    environment: E2E
+    needs: test
     steps:
       - name: Check out code into the project directory
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
           VALIDATE_MARKDOWN: false
           VALIDATE_JSCPD: false
           VALIDATE_SHELL_SHFMT: false
-  test:
-    name: Unit Testing and Build
+  test-linux:
+    name: Unit Testing and Build on Linux x64
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -82,8 +82,8 @@ jobs:
           name: darwin-amd64-binary
           path: ./bin/artifacts/notation-azure-kv_0.0.1_darwin_amd64.tar.gz
           retention-days: 1
-  test-arm:
-    name: Unit Testing and Build on ARM
+  test-linux-arm:
+    name: Unit Testing and Build on Linux ARM64
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     permissions:
@@ -99,10 +99,6 @@ jobs:
           fetch-depth: 0
       - name: Run unit tests
         run: make test
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Build Linux Binary
         run: |
           # the binary will be used in E2E test
@@ -113,11 +109,36 @@ jobs:
           name: linux-arm64-binary
           path: ./bin/artifacts/notation-azure-kv_0.0.1_linux_arm64.tar.gz
           retention-days: 1
+  test-windows:
+    name: Unit Testing and Build on windows x64
+    runs-on: windows-2022
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Check out code into the project directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run unit tests
+        run: make test
+      - name: Build Windows Binary
+        run: python3 ./scripts/build.py v0.0.1 win-x64 --enable-aot
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-amd64-binary
+          path: ./bin/artifacts/notation-azure-kv_0.0.1_windows-amd64.tar.gz
+          retention-days: 1
   e2e-mariner-container:
     name: E2E testing for Mariner container
     runs-on: ubuntu-latest
     environment: E2E
-    needs: test
+    needs: test-linux
     steps:
       - name: Check out code into the project directory
         uses: actions/checkout@v4
@@ -172,7 +193,7 @@ jobs:
           - os: ubuntu-22.04-arm
             arch: arm64
     environment: E2E
-    needs: [test, test-arm]
+    needs: [test-linux, test-linux-arm]
     steps:
       - name: Check out code into the project directory
         uses: actions/checkout@v4
@@ -215,18 +236,16 @@ jobs:
       matrix:
         os: [windows-2022, windows-2025]
     environment: E2E
-    needs: test
+    needs: test-windows
     steps:
       - name: Check out code into the project directory
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+      - uses: actions/download-artifact@v4
         with:
-          dotnet-version: '8.0.x'
-      - name: Build Windows Binary
-        run: python3 ./scripts/build.py v0.0.1 win-x64 --enable-aot
+          name: windows-amd64-binary
+          path: ./bin/artifacts
       - name: Run download server locally
         run: |
           # wsl bash
@@ -260,7 +279,7 @@ jobs:
     name: E2E testing on macOS
     runs-on: macos-13
     environment: E2E
-    needs: test
+    needs: test-linux
     steps:
       - name: Check out code into the project directory
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,9 +126,49 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_FEDERATED_TOKEN_FILE: ./federated_token
-  e2e-linux:
+  e2e-ubuntu-2404:
     name: E2E testing on Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    environment: E2E
+    needs: test
+    steps:
+      - name: Check out code into the project directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: linux-amd64-binary
+          path: ./bin/artifacts
+      - name: Run download server locally
+        run: |
+          nohup python3 -m http.server --directory ./bin/artifacts/ &
+
+          # prepare the environment variables for E2E
+          artifactName=notation-azure-kv_0.0.1_linux_amd64.tar.gz
+          checksum=$(shasum -a 256 "./bin/artifacts/$artifactName" | awk '{print $1}')
+          echo "pluginChecksum=$checksum" >> "$GITHUB_ENV"
+          echo "pluginDownloadURL=http://localhost:8000/$artifactName" >> "$GITHUB_ENV"
+      - name: Prepare container registry
+        run: |
+          docker run --name registry --rm -d -p 5000:5000 registry:2
+          docker pull hello-world:latest
+          docker tag hello-world:latest localhost:5000/hello-world:v1
+          docker push localhost:5000/hello-world:v1
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: E2E testing
+        uses: ./test/e2e
+        with:
+          pluginDownloadURL: ${{ env.pluginDownloadURL }}
+          pluginChecksum: ${{ env.pluginChecksum }}
+  e2e-ubuntu-2204:
+    name: E2E testing on Linux
+    runs-on: ubuntu-22.04
     environment: E2E
     needs: test
     steps:


### PR DESCRIPTION
CI:
- E2E pipeline
  - linux-x64 will be built on ubuntu-24.04 and tested on ubuntu-22.04, ubuntu-24.04 and `mcr.microsoft.com/cbl-mariner/base/core:2.0` container
  - linux-arm64 will be built ubuntu-24.04-arm and tested on ubuntu-24.04-arm, ubuntu-22.04-arm
  - windows-x64 will be built on windows-2022 and tested on windows-2022 and windows-2025 (GA)
- release pipeline
  -  updated release pipeline to use ubuntu 24.04 fixed version runner
  - removed ARM emulator from release pipeline and replaced with ubuntu 24.04-arm runner

Background: The dotnet building process depends on OS libraries. As the default `ubuntu-latest` runner [has upgraded](https://github.com/actions/runner-images/commit/976232da217887825e7541c2635bf39cbbf22654_ to `ubuntu-24.04`, we need to ensure compatibility with older OS versions.

Note: win-x64 build generates a warning which is discussed here: https://github.com/dotnet/runtime/issues/109958. It should be fixed in the future dotnet release.